### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use a plugin manager of your choice to install it ([Pathogen], [Vundle], ...),
 or simple copy `bubblelighgts.vim` into `~/.vimrc/colors`:
 
 ```bash
-wget https://github.com/hagenw/bubblelights/raw/master/colors/bubblelights.vim \
+wget https://github.com/hagenw/bubblelights/raw/main/colors/bubblelights.vim \
      -O ~/.vimrc/colors/bubblelights.vim
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A colortheme for vim based on [bubblegum] and [southernlights].
 ## Installation
 
 Use a plugin manager of your choice to install it ([Pathogen], [Vundle], ...),
-or simple copy `bubblelighgts.vim` into `~/.vimrc/colors`:
+or simple copy `bubblelighgts.vim` into `~/.vim/colors`:
 
 ```bash
 wget https://github.com/hagenw/bubblelights/raw/main/colors/bubblelights.vim \
-     -O ~/.vimrc/colors/bubblelights.vim
+     -O ~/.vim/colors/bubblelights.vim
 ```
 
 [Pathogen]: (https://github.com/tpope/vim-pathogen)

--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ A colortheme for vim based on [bubblegum] and [southernlights].
 
 ## Installation
 
-Use a plugin manager of your choice to install it ([Pathogen], [Vundle], ...),
-or simple copy `bubblelighgts.vim` into `~/.vim/colors`:
+Add it as a package to vim
+(see `:help packages`)
+with:
 
 ```bash
+mkdir -p ~/.vim/pack/colors/opt/bubblelights/colors/
 wget https://github.com/hagenw/bubblelights/raw/main/colors/bubblelights.vim \
-     -O ~/.vim/colors/bubblelights.vim
+     -O ~/.vim/pack/colors/opt/bubblelights/colors/bubblelights.vim
 ```
 
-[Pathogen]: (https://github.com/tpope/vim-pathogen)
-[Vundle]: (https://github.com/VundleVim/Vundle.vim)
-
 Then enable the colorscheme in your `~/.vimrc` with the following command:
-`colorscheme bubblelights`.
+
+```vim
+colorscheme bubblelights
+```
 
 If you only use GVim, you're done! If you use terminal Vim, read on...
 


### PR DESCRIPTION
As `vim` has now build-in support for plugins we do no longer need to recommend a third-party plugin manager nor copy directly to the color folder under `.vim/`, but can recommend to store it under `.vim/pack`.

![image](https://github.com/hagenw/bubblelights/assets/173624/2b8d195e-c885-4420-ba83-b4e174297781)
